### PR TITLE
ci: authenticate release workflow as axeptio-bot

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -47,9 +47,9 @@ jobs:
     name: Validate commit messages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: commitlint.config.mjs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,16 +17,34 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Authenticate as axeptio-bot (BOT_GITHUB_TOKEN). The enterprise forbids
+      # the default GITHUB_TOKEN from creating PRs; the bot is allowed to and
+      # may bypass the PR requirement when pushing the metadata sync commit.
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       # The steps below only run when a release was just published.
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.releases_created == 'true' }}
+        with:
+          # Use the bot token so the follow-up push authenticates as the bot
+          # (and can bypass branch protection on master).
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      # Import the bot's GPG key so the metadata commit is signed (required if
+      # master enforces signed commits). Also sets git user.name/email from the
+      # key identity and enables commit signing globally.
+      - name: Import bot GPG key
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
 
       - uses: actions/setup-node@v4
         if: ${{ steps.release.outputs.releases_created == 'true' }}
@@ -44,8 +62,6 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: |
           if [[ -n "$(git status --porcelain metadata.yaml)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add metadata.yaml
             git commit -m "chore(metadata): sync version history for ${{ steps.release.outputs['.--tag_name'] }}"
             git push

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
       # Authenticate as axeptio-bot (BOT_GITHUB_TOKEN). The enterprise forbids
       # the default GITHUB_TOKEN from creating PRs; the bot is allowed to and
       # may bypass the PR requirement when pushing the metadata sync commit.
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
         id: release
         with:
           config-file: release-please-config.json
@@ -28,7 +28,7 @@ jobs:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       # The steps below only run when a release was just published.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           # Use the bot token so the follow-up push authenticates as the bot
@@ -40,13 +40,13 @@ jobs:
       # key identity and enables commit signing globally.
       - name: Import bot GPG key
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           node-version: 20


### PR DESCRIPTION
## Why

The first `Release` run after #8 merged failed with:

> GitHub Actions is not permitted to create or approve pull requests — *The enterprise does not allow GitHub Actions to create or approve pull requests.*

That's an **enterprise-level** policy (not overridable per-repo), and it blocks release-please's default `GITHUB_TOKEN` from opening its release PR.

## Fix

Authenticate the release workflow as **`axeptio-bot`** (which is allowed to create PRs and bypass the PR requirement on `master`):

- release-please now uses `token: ${{ secrets.BOT_GITHUB_TOKEN }}`.
- The `metadata.yaml` sync step checks out and pushes with the same bot token, so the direct push to `master` authenticates as the bot.
- The sync commit is **GPG-signed** with `BOT_GPG_PRIVATE_KEY` (via `crazy-max/ghaction-import-gpg`), in case `master` enforces signed commits.

Uses existing org secrets: `BOT_GITHUB_TOKEN`, `BOT_GPG_PRIVATE_KEY`.

## After merge

The push to `master` will trigger the fixed workflow, which should open the first release PR (a `fix:` commit is already on `master`, so expect a `1.0.1` proposal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)