### PR TITLE
ci: use root-component outputs for release metadata sync

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
 
       # The steps below only run when a release was just published.
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         with:
           # Use the bot token so the follow-up push authenticates as the bot
           # (and can bypass branch protection on master).
@@ -39,7 +39,7 @@ jobs:
       # master enforces signed commits). Also sets git user.name/email from the
       # key identity and enables commit signing globally.
       - name: Import bot GPG key
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
@@ -47,23 +47,23 @@ jobs:
           git_commit_gpgsign: true
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         with:
           node-version: 20
 
       - name: Sync metadata.yaml version history
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
-          RELEASE_TAG: ${{ steps.release.outputs['.--tag_name'] }}
-          RELEASE_SHA: ${{ steps.release.outputs['.--sha'] }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
         run: node scripts/update-metadata-version.mjs
 
       - name: Commit metadata.yaml
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         run: |
           if [[ -n "$(git status --porcelain metadata.yaml)" ]]; then
             git add metadata.yaml
-            git commit -m "chore(metadata): sync version history for ${{ steps.release.outputs['.--tag_name'] }}"
+            git commit -m "chore(metadata): sync version history for ${{ steps.release.outputs.tag_name }}"
             git push
           else
             echo "metadata.yaml already up to date; nothing to commit."

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,3 +17,6 @@ documentation: "https://www.example.com/documentation"
 versions:
   - sha: f311fd0a2da4911824ff9dfd435805ec89d083a4
     changeNotes: Initial Version
+  - sha: a299456826a01e4db72e593ed01c35fe7cd000cd
+    changeNotes: |-
+      - **ci:** use .mjs commitlint config required by commitlint action


### PR DESCRIPTION
## Why

After merging the v1.0.1 release PR (#11), the release was cut correctly (tag `v1.0.1` + GitHub Release), but the **`Sync metadata.yaml` step failed**:

> RELEASE_TAG and RELEASE_SHA must both be set.

**Root cause:** for a **root component** (path `.`), `release-please-action` exposes its outputs *without* a path prefix — `tag_name`, `sha`, `release_created`. The workflow used the path-prefixed forms (`['.--tag_name']`, `['.--sha']`), which only apply to monorepo/non-root paths, so they resolved to empty. ([action docs](https://github.com/googleapis/release-please-action#root-component-outputs))

## Fix

- Use the root-component output names: `tag_name`, `sha`, and gate on `release_created`.
- **Backfill** the `metadata.yaml` entry for `v1.0.1` that the failed run skipped (sha `a299456`).

No new release is triggered — this is a `ci:` change (non-bumping), so release-please won't open a release PR for it. Future releases will sync `metadata.yaml` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)