### PR TITLE
feat: replace Apache 2.0 with Axeptio license notice (from v1.2.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,17 +3,13 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-## Contributor License Agreement
+## Contributions and licensing
 
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
+From version `1.2.0`, this template is distributed under Axeptio's licensing
+terms (see [LICENSE](./LICENSE)); earlier versions remain under the Apache
+License 2.0. By submitting a contribution you agree that it is provided under,
+and may be redistributed as part of this project under, those Axeptio licensing
+terms.
 
 ## Code reviews
 
@@ -93,5 +89,5 @@ docs: clarify the import steps
 
 ## Community Guidelines
 
-This project follows
-[Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).
+Please be respectful and constructive in issues and pull requests. For questions
+about the template or Axeptio, see the [Axeptio documentation](https://www.axept.io/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,24 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Axeptio sGTM Public Template — License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Versions published before 1.2.0 were released under the Apache License 2.0 and
+remain governed by it (that grant is irreversible for those versions). Starting
+from version 1.2.0, this content is licensed under Axeptio's licensing terms as
+set out in the notice below.
 
-   1. Definitions.
+--------------------------------------------------------------------------------
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+IMPORTANT LICENSE NOTICE
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+Starting from version 1.2.0, this content is subject to Axeptio's licensing terms, which are accessible at: https://www.axept.io/fr/?axeptio_contract=terms_of_use_en
+By using this content, you acknowledge that you hold a valid Axeptio license and expressly agree to these Licensing Terms.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+Mandatory Updates: To ensure optimal performance, security, and compatibility with Axeptio services, you are required to use the most up-to-date version of this content. Agilitation disclaims any liability, warranty, or technical support for issues or security vulnerabilities arising from the use of outdated versions.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+--------------------------------------------------------------------------------
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+AVIS IMPORTANT CONCERNANT LA LICENCE
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+A partir de la version 1.2.0, ce contenu est soumis aux termes de la licence Axeptio, disponibles à l'adresse suivante: https://www.axept.io/fr/?axeptio_contract=terms_of_use_fr
+En utilisant ce contenu, vous reconnaissez disposer d'une licence Axeptio valide et accepter sans réserve ces Conditions de Licence.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Mises à jour obligatoires : Afin de garantir des performances optimales, la sécurité et une compatibilité avec les services d'Axeptio, vous êtes tenu d'utiliser la version la plus récente de ce contenu. Agilitation décline toute responsabilité, garantie ou obligation de support technique pour les problèmes ou failles de sécurité résultant de l'utilisation de versions obsolètes.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository provides a **Google Tag Manager (GTM) Server-Side** template tha
    - [Step 3: Test the Configuration](#step-3-test-the-configuration)
 5. [Troubleshooting and Support](#troubleshooting-and-support)
 6. [Versioning and Releases](#versioning-and-releases)
+7. [License](#license)
 
 
 <br><br>
@@ -126,3 +127,26 @@ updated, a git tag and a [GitHub Release](../../releases) are published, and the
 GTM `versions:` history in `metadata.yaml` is appended automatically.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the commit message conventions.
+
+<br><br>
+
+## License
+
+Versions published before `1.2.0` were released under the **Apache License 2.0**
+and remain governed by it. **Starting from version `1.2.0`, this template is
+licensed under Axeptio's licensing terms** as set out below (see also the
+[LICENSE](./LICENSE) file). English and French versions follow.
+
+> **IMPORTANT LICENSE NOTICE**
+>
+> Starting from version 1.2.0, this content is subject to Axeptio's licensing terms, which are accessible at: <https://www.axept.io/fr/?axeptio_contract=terms_of_use_en>
+> By using this content, you acknowledge that you hold a valid Axeptio license and expressly agree to these Licensing Terms.
+>
+> **Mandatory Updates:** To ensure optimal performance, security, and compatibility with Axeptio services, you are required to use the most up-to-date version of this content. Agilitation disclaims any liability, warranty, or technical support for issues or security vulnerabilities arising from the use of outdated versions.
+
+> **AVIS IMPORTANT CONCERNANT LA LICENCE**
+>
+> A partir de la version 1.2.0, ce contenu est soumis aux termes de la licence Axeptio, disponibles à l'adresse suivante : <https://www.axept.io/fr/?axeptio_contract=terms_of_use_fr>
+> En utilisant ce contenu, vous reconnaissez disposer d'une licence Axeptio valide et accepter sans réserve ces Conditions de Licence.
+>
+> **Mises à jour obligatoires :** Afin de garantir des performances optimales, la sécurité et une compatibilité avec les services d'Axeptio, vous êtes tenu d'utiliser la version la plus récente de ce contenu. Agilitation décline toute responsabilité, garantie ou obligation de support technique pour les problèmes ou failles de sécurité résultant de l'utilisation de versions obsolètes.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,16 +1,12 @@
-# Copyright 2019 Google LLC
+# Axeptio sGTM Public Template
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# IMPORTANT LICENSE NOTICE
+# Starting from version 1.2.0, this content is subject to Axeptio's licensing
+# terms: https://www.axept.io/fr/?axeptio_contract=terms_of_use_en
+# By using this content you acknowledge that you hold a valid Axeptio license and
+# expressly agree to these Licensing Terms. See the LICENSE file for the full
+# notice (English and French). Versions published before 1.2.0 remain under the
+# Apache License 2.0.
 
 homepage: "https://www.example.com"
 documentation: "https://www.example.com/documentation"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "axeptio-sgtm-public-template",
       "version": "0.0.0",
-      "license": "Apache-2.0",
+      "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "js-yaml": "^4.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   "devDependencies": {
     "js-yaml": "^4.1.0"
   },
-  "license": "Apache-2.0"
+  "license": "SEE LICENSE IN LICENSE"
 }


### PR DESCRIPTION
## What & why

Replaces the **Apache 2.0** license with **Axeptio's licensing notice** for this
sGTM public template, **going forward from v1.2.0**. Per ENG-13012, Apache 2.0 on
already-published tags (`v1.0.1` / `v1.1.0` / `v1.1.1`) is irreversible and stays
untouched — this change only applies to new versions.

The `feat:` title bumps release-please **1.1.1 → 1.2.0**, matching the version
cited in the notice.

Linear: [ENG-13012](https://linear.app/axeptio/issue/ENG-13012)

## Changes

| File | Change |
| --- | --- |
| `LICENSE` | Apache 2.0 text → bilingual (EN/FR) Axeptio notice |
| `README.md` | New `## License` section + TOC entry with the notice |
| `metadata.yaml` | Google/Apache header comment → Axeptio license comment |
| `CONTRIBUTING.md` | Drop Google CLA + community-guidelines boilerplate |
| `package.json` / `package-lock.json` | `license: Apache-2.0` → `SEE LICENSE IN LICENSE` |

Notice text is copied **verbatim** from the ticket (both languages), with
`[Nouvelle_Version]` → `1.2.0`. "Agilitation" (Axeptio's legal entity) kept as
written.

## Scope

Only `axeptio-sgtm-public-template`. Sibling repos (`axeptio-gtm-public-template`,
`axeptio-client-sgtm-public-template`) are separate follow-ups.

## ⛔ Draft — merge gated on

1. **Confirm the `1.2.0` wording with the sender.** The ticket said "add the
   current version"; interpreted as the first release *bearing* the notice
   (next = 1.2.0), since 1.1.1 already shipped under Apache.
2. **Coordinate timing with Jérôme's quote-template update** (adding these
   connectors to Axeptio offers) so the notice and the commercial offering land
   together.

## Verification

- `npm test` → 15/15 template tests pass (docs/license-only change, no routing touched)
- `metadata.yaml` valid YAML; `package.json` valid JSON
- Apache/Google references remain only in the intended "prior versions stay under
  Apache 2.0" transition notes
- `git show v1.1.1:LICENSE` still shows Apache (history preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)