### PR TITLE
chore(metadata): sync version history for v1.2.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,3 +27,6 @@ versions:
   - sha: 6557523481fedee9b30a87e4096a7ec08e7f99bd
     changeNotes: |-
       - **test:** tighten deepEqual key-set check in template test runner
+  - sha: 0c5811dde913854007afdab6e0ce25a8871aff53
+    changeNotes: |-
+      - replace Apache 2.0 with Axeptio license notice (from v1.2.0)


### PR DESCRIPTION
Backfills the `v1.2.0` entry in `metadata.yaml`'s GTM version history.

The v1.2.0 release published its tag + GitHub Release fine, but the release
workflow's `Commit metadata.yaml` step (which pushes this entry directly to
master) was rejected by branch protection — `Run template tests` was a required
status check with no per-actor bypass in classic protection. That's now fixed
(check moved to a ruleset with the bot in the bypass list), but this one entry
still needs backfilling since re-running the release job reports
`release_created=false` and skips the sync.

Generated with `scripts/update-metadata-version.mjs` (RELEASE_TAG=v1.2.0,
RELEASE_SHA=0c5811d); the duplicate changeNote the script emitted — an artifact
of PR #17 landing as a merge commit rather than a squash, so the CHANGELOG has
the `feat` line twice — was collapsed to one.

`chore:` → no version bump.

Ref: ENG-13012

🤖 Generated with [Claude Code](https://claude.com/claude-code)