### PR TITLE
test(template): guard against GTM-illegal characters in test names

### DIFF
--- a/test/run-tpl-tests.mjs
+++ b/test/run-tpl-tests.mjs
@@ -203,6 +203,27 @@ if (scenarios.length === 0) {
   });
 }
 
+// --- Guard: GTM test-name legality. -------------------------------------------
+// GTM's Custom Template editor validates each ___TESTS___ scenario name and
+// rejects punctuation (e.g. "."), which silently blocks saving template.tpl in
+// the GTM UI. Catch it here in CI instead. Allowlist known-safe characters
+// rather than blocklisting, since GTM's full rejected set is undocumented.
+const GTM_SAFE_NAME = /^[A-Za-z0-9 _-]+$/;
+
+test('all scenario names are GTM-legal', () => {
+  // Self-check: the guard must actually reject the characters we care about.
+  for (const bad of ['has.dot', 'a/b', 'a,b', 'a(b)']) {
+    if (GTM_SAFE_NAME.test(bad)) throw new Error(`guard is too permissive: accepted "${bad}"`);
+  }
+  const illegal = scenarios.map((s) => s.name).filter((name) => !GTM_SAFE_NAME.test(name));
+  if (illegal.length > 0) {
+    throw new Error(
+      'These test names contain characters GTM rejects (use letters, numbers, ' +
+      `spaces, hyphens, underscores only):\n  ${illegal.join('\n  ')}`,
+    );
+  }
+});
+
 for (const scenario of scenarios) {
   test(scenario.name, () => {
     const api = buildTestApi();


### PR DESCRIPTION
## What

Add a CI guard to `test/run-tpl-tests.mjs` that fails the build when any `___TESTS___` scenario name contains characters GTM's Custom Template editor rejects.

## Why

[SUP-992](https://linear.app/axeptio/issue/SUP-992) fixed 8 test names whose punctuation (`.`, `/`, `,`, `()`) silently blocked saving `template.tpl` in the GTM editor. Nothing in CI caught it — the runner executed each scenario by name but never validated the name. Google ships no standalone linter for this; the rule is enforced only inside the GTM UI. This turns a "blocked when saving in GTM" surprise into a red CI check.

## How

- One test, `all scenario names are GTM-legal`, asserts every `scenario.name` matches an allowlist of known-safe characters `^[A-Za-z0-9 _-]+$` (letters, numbers, spaces, hyphens, underscores).
- **Allowlist, not blocklist** — GTM's full rejected set is undocumented, so we permit only characters known to be safe.
- Includes a **self-check** proving the regex rejects `has.dot`, `a/b`, `a,b`, `a(b)`, so a too-permissive regex can't pass silently.
- Runs inside the existing `test.yml` workflow — no new workflow.

## Verification

- `npm test` → **16 pass / 0 fail** (15 scenarios + the new guard)
- Injected a `.` into one scenario name locally → guard fails and names the offender; reverted.

Refs SUP-993

🤖 Generated with [Claude Code](https://claude.com/claude-code)
