### PR TITLE
test(template): add hermetic integration harness with local mock upstreams

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+      # Hermetic integration suite: real sandboxed JS over real HTTP against a
+      # local mock of the Axeptio upstreams (127.0.0.1 only, no egress). Covers
+      # byte-identical binary relay, header allowlist/strip behavior and
+      # status/error semantics that the mocked ___TESTS___ scenarios cannot.
+      - run: npm run integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,22 @@ npm test    # runs every ___TESTS___ scenario against the real template source
 Node's built-in test runner, so a change that breaks routing fails the suite. Add
 or update a scenario in `___TESTS___` whenever you change the tag's behaviour.
 
-A CI check (`Test template`) runs `npm test` on every pull request and **must
-pass before merging** (add it to the branch's required status checks).
+Beyond the mocked scenarios, a hermetic integration suite runs the same real
+sandboxed source over real HTTP against a local mock of the Axeptio upstreams
+(binds `127.0.0.1` only — no network egress):
+
+```
+npm run integration   # byte-identical binary relay, header allowlist/strip,
+                      # status/error relay, base-path stripping over the wire
+```
+
+See `integration/lib/gtm-runtime.mjs` for its fidelity contract: it complements
+the live e2e suite (`npm run e2e`), which remains the only proof of end-to-end
+binary integrity on a real tagging server.
+
+A CI check (`Test template`) runs `npm test` and `npm run integration` on every
+pull request and **must pass before merging** (add it to the branch's required
+status checks).
 
 ## Commit & pull request conventions
 

--- a/integration/lib/gtm-runtime.mjs
+++ b/integration/lib/gtm-runtime.mjs
@@ -1,0 +1,140 @@
+// Runs the REAL ___SANDBOXED_JS_FOR_SERVER___ from template.tpl as close to the
+// sGTM request lifecycle as possible without Google's runtime: the
+// sendHttpRequest shim performs a real HTTP request (rewritten to the local
+// mock upstream), and the response-writing APIs capture what would be returned
+// to the caller.
+//
+// Fidelity contract: bytes cross the sandbox boundary with a latin1
+// byte<->string convention, so these tests prove the template relays whatever
+// the runtime hands it, byte for byte. Real sGTM stringifies bodies as UTF-8 —
+// only the live e2e suite (e2e/proxy-e2e.mjs) can prove end-to-end binary
+// integrity on a real tagging server. This harness complements e2e; it never
+// replaces it.
+
+import vm from 'node:vm';
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { loadTemplate, spy } from '../../lib/template.mjs';
+
+const TPL_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'template.tpl');
+
+export const { sandboxSource, sections } = loadTemplate(TPL_PATH);
+
+// Mirror of the send_http permission in ___SERVER_PERMISSIONS___ ("specific"
+// allowedUrls: https://*.axept.io/* and https://*.axeptio.eu/*). The shim
+// enforces it BEFORE rewriting to the local mock, so the rewrite can never
+// mask a URL the real GTM sandbox would reject. A test in
+// proxy-integration.mjs asserts the permission section still matches this
+// mirror, closing the drift loop.
+const ALLOWED_URLS = [/^https:\/\/[^/]+\.axept\.io\//, /^https:\/\/[^/]+\.axeptio\.eu\//];
+
+export function assertUrlAllowed(url) {
+  if (!ALLOWED_URLS.some((re) => re.test(url))) {
+    throw new Error(`send_http permission would reject URL: ${url}`);
+  }
+}
+
+// Executes the tag once and resolves with what it returned to the caller.
+//   path/queryString/method/body/requestHeaders — the incoming request
+//   (queryString without leading '?', body as string or Buffer, header lookup
+//   case-insensitive like sGTM's).
+//   data — tag configuration (proxyBasePath, enableLogging).
+//   upstreamPort — the mock-upstream server port.
+export function runProxyTag({
+  path = '/',
+  queryString = '',
+  method = 'GET',
+  body,
+  requestHeaders = {},
+  data = {},
+  upstreamPort,
+} = {}) {
+  return new Promise((resolve, reject) => {
+    const result = { status: undefined, headers: {}, body: '', logs: [] };
+    const gtmOnSuccess = spy();
+    const gtmOnFailure = spy();
+
+    const timer = setTimeout(
+      () => reject(new Error('returnResponse was not called within 2s')),
+      2000,
+    );
+
+    const headerLookup = (name) => {
+      const wanted = String(name).toLowerCase();
+      for (const key of Object.keys(requestHeaders)) {
+        if (key.toLowerCase() === wanted) return requestHeaders[key];
+      }
+      return undefined;
+    };
+
+    const sendHttpRequest = (url, options = {}, requestBody) => {
+      assertUrlAllowed(url);
+      const u = new URL(url);
+      const rewritten = `http://127.0.0.1:${upstreamPort}/${u.host}${u.pathname}${u.search}`;
+      return new Promise((res, rej) => {
+        const req = http.request(
+          rewritten,
+          { method: options.method || 'GET', headers: options.headers || {} },
+          (r) => {
+            const chunks = [];
+            r.on('data', (c) => chunks.push(c));
+            r.on('end', () => res({
+              statusCode: r.statusCode,
+              headers: r.headers,
+              body: Buffer.concat(chunks).toString('latin1'),
+            }));
+            r.on('error', rej);
+          },
+        );
+        req.on('error', rej);
+        if (requestBody !== undefined && requestBody !== null) {
+          req.write(Buffer.isBuffer(requestBody) ? requestBody : Buffer.from(requestBody, 'latin1'));
+        }
+        req.end();
+      });
+    };
+
+    const apis = {
+      getRequestPath: () => path,
+      getRequestQueryString: () => queryString,
+      getRequestBody: () => (Buffer.isBuffer(body) ? body.toString('latin1') : body),
+      getRequestHeader: headerLookup,
+      getRequestMethod: () => method,
+      logToConsole: (...args) => { result.logs.push(args); },
+      sendHttpRequest,
+      setResponseStatus: (s) => { result.status = s; },
+      setResponseBody: (b) => { result.body = b; },
+      setResponseHeader: (k, v) => { result.headers[String(k).toLowerCase()] = v; },
+      returnResponse: () => {
+        clearTimeout(timer);
+        // Resolve via microtask so the template's post-returnResponse calls
+        // (data.gtmOnSuccess/Failure) have run before the test's await resumes.
+        queueMicrotask(() => resolve({
+          status: result.status,
+          headers: result.headers,
+          body: Buffer.from(result.body || '', 'latin1'),
+          gtmOnSuccessCalls: gtmOnSuccess.calls.length,
+          gtmOnFailureCalls: gtmOnFailure.calls.length,
+          logs: result.logs,
+        }));
+      },
+    };
+
+    const context = vm.createContext({
+      require: (name) => {
+        if (name in apis) return apis[name];
+        throw new Error(`integration runtime: template required unshimmed API '${name}'`);
+      },
+      data: Object.assign({}, data, { gtmOnSuccess, gtmOnFailure }),
+      Object, Array, JSON, Math, String, Number,
+    });
+
+    try {
+      vm.runInContext(`(function () {\n${sandboxSource}\n})();`, context, { timeout: 2000 });
+    } catch (err) {
+      clearTimeout(timer);
+      reject(err);
+    }
+  });
+}

--- a/integration/lib/mock-upstream.mjs
+++ b/integration/lib/mock-upstream.mjs
@@ -1,0 +1,82 @@
+// Local fixture server standing in for the Axeptio upstream origins during
+// integration tests. The gtm-runtime shim rewrites https://<host>/<path> to
+// http://127.0.0.1:<port>/<host>/<path>, so the first path segment names the
+// emulated origin: one server covers all origins while every test can assert
+// exactly which origin was hit and with what.
+
+import http from 'node:http';
+
+// Deterministic 4KB binary covering every byte value 0x00-0xFF, including
+// sequences that are invalid UTF-8 — the corruption class the byte-identity
+// tests exist to catch — without committing binary blobs to git.
+export function patternBytes() {
+  return Buffer.from(Array.from({ length: 4096 }, (_, i) => (i * 7 + 13) & 0xff));
+}
+
+export function startMockUpstream() {
+  // Every request the emulated origins received, for test assertions.
+  const requests = [];
+
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks);
+      const url = new URL(req.url, 'http://mock');
+      const [, host, ...rest] = url.pathname.split('/');
+      const route = '/' + rest.join('/');
+      requests.push({ method: req.method, host, route, query: url.search.slice(1), headers: req.headers, body });
+
+      // The /api/v1/ namespace remaps to the upstream's /v1/ prefix; fixtures
+      // are addressed the same on every origin, so drop it before dispatch.
+      const fixture = route.replace(/^\/v1/, '');
+
+      if (fixture.startsWith('/bin/pattern')) {
+        res.writeHead(200, { 'Content-Type': url.searchParams.get('ct') || 'application/octet-stream' });
+        res.end(patternBytes());
+      } else if (fixture.startsWith('/echo')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          method: req.method,
+          route,
+          query: url.search.slice(1),
+          headers: req.headers,
+          bodyBase64: body.toString('base64'),
+        }));
+      } else if (fixture.startsWith('/status/')) {
+        const status = Number(fixture.split('/')[2]);
+        const headers = { 'X-Marker': 'status-fixture' };
+        if (status === 301) headers.Location = 'https://example.com/moved';
+        res.writeHead(status, headers);
+        // 204/304 must not carry a body; Node enforces this.
+        res.end(status === 204 || status === 304 ? undefined : `status-${status}`);
+      } else if (fixture.startsWith('/hop-headers')) {
+        // Hop-by-hop headers the template must strip, plus one it must relay.
+        // Transfer-Encoding itself would break Node's response framing, so the
+        // strip list's other members stand in for it.
+        res.writeHead(200, {
+          'Keep-Alive': 'timeout=5',
+          'Proxy-Authenticate': 'Basic',
+          'Upgrade': 'h2c',
+          'X-Custom': 'keep-me',
+        });
+        res.end('hop');
+      } else if (fixture.startsWith('/network-error')) {
+        req.socket.destroy();
+      } else {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('mock: no fixture for ' + route);
+      }
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: server.address().port,
+        requests,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}

--- a/integration/proxy-integration.mjs
+++ b/integration/proxy-integration.mjs
@@ -1,0 +1,167 @@
+// Integration matrix for the reverse-proxy template: real sandboxed JS, real
+// HTTP, local mock upstreams (zero network egress — everything binds
+// 127.0.0.1). Covers what the mocked ___TESTS___ scenarios cannot: byte
+// integrity, real header traffic, and status/error semantics over the wire.
+// See integration/lib/gtm-runtime.mjs for the fidelity contract vs live e2e.
+//
+// Not discovered by bare `node --test` (which only picks up test/): run with
+// `npm run integration`.
+
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { startMockUpstream, patternBytes } from './lib/mock-upstream.mjs';
+import { runProxyTag, assertUrlAllowed, sections } from './lib/gtm-runtime.mjs';
+
+let mock;
+before(async () => { mock = await startMockUpstream(); });
+after(() => mock.close());
+beforeEach(() => { mock.requests.length = 0; });
+
+const run = (opts) => runProxyTag({ upstreamPort: mock.port, ...opts });
+
+// --- Permission-mirror drift guard. -------------------------------------------
+test('send_http permission section still matches the shim mirror', () => {
+  const perms = sections.___SERVER_PERMISSIONS___;
+  assert.match(perms, /https:\/\/\*\.axept\.io\/\*/);
+  assert.match(perms, /https:\/\/\*\.axeptio\.eu\/\*/);
+  assertUrlAllowed('https://api.axept.io/v1/app');
+  assertUrlAllowed('https://static.axeptio.eu/x.js');
+  for (const bad of ['https://evil.example.com/', 'http://api.axept.io/v1', 'https://axept.io/x', 'https://api.axept.io.evil.com/']) {
+    assert.throws(() => assertUrlAllowed(bad), /send_http permission/, bad);
+  }
+});
+
+// --- 1. Routing: every namespace reaches its origin with the prefix remapped. --
+const ROUTING = [
+  ['/static-eu/echo', 'static.axeptio.eu', '/echo'],
+  ['/static/echo', 'static.axept.io', '/echo'],
+  ['/client/echo', 'client.axept.io', '/echo'],
+  ['/api/v1/echo', 'api.axept.io', '/v1/echo'],
+  ['/favicons/echo', 'favicons.axept.io', '/echo'],
+  ['/fonts/echo', 'fonts.axept.io', '/echo'],
+  ['/consents', 'api.axept.io', '/v1/app/consents'],
+];
+
+for (const [path, host, route] of ROUTING) {
+  test(`routes ${path} to ${host}${route}`, async () => {
+    await run({ path });
+    assert.equal(mock.requests.length, 1);
+    assert.equal(mock.requests[0].host, host);
+    assert.equal(mock.requests[0].route, route);
+  });
+}
+
+// --- 2. Binary relay is byte-identical. ----------------------------------------
+for (const [path, ct] of [['/fonts/bin/pattern?ct=font%2Fwoff2', 'font/woff2'], ['/favicons/bin/pattern?ct=image%2Fpng', 'image/png']]) {
+  test(`binary relay through ${path.split('/')[1]} is byte-identical`, async () => {
+    const [p, q] = path.split('?');
+    const res = await run({ path: p, queryString: q });
+    assert.equal(res.status, 200);
+    assert.ok(res.body.equals(patternBytes()), 'relayed bytes differ from upstream bytes');
+    assert.equal(res.headers['content-type'], ct);
+    assert.equal(res.gtmOnSuccessCalls, 1);
+  });
+}
+
+// --- 3. Request preservation: method, body, query, header allowlist. -----------
+test('POST body query and allowlisted headers reach the upstream verbatim', async () => {
+  const body = '{"token":"abc","accept":true}';
+  const res = await run({
+    path: '/api/v1/echo',
+    queryString: 'clientId=abc&v=1',
+    method: 'POST',
+    body,
+    requestHeaders: {
+      'content-type': 'application/json',
+      'User-Agent': 'sgtm-integration',
+      'X-Forwarded-For': '203.0.113.7',
+      'Cookie': 'secret=1',
+    },
+  });
+  assert.equal(res.status, 200);
+  const echo = JSON.parse(res.body.toString());
+  assert.equal(echo.method, 'POST');
+  assert.equal(echo.route, '/v1/echo');
+  assert.equal(echo.query, 'clientId=abc&v=1');
+  assert.equal(Buffer.from(echo.bodyBase64, 'base64').toString(), body);
+  // Allowlisted headers forwarded (case-insensitive lookup), others never leak.
+  assert.equal(echo.headers['content-type'], 'application/json');
+  assert.equal(echo.headers['user-agent'], 'sgtm-integration');
+  assert.equal(echo.headers['x-forwarded-for'], undefined);
+  assert.equal(echo.headers['cookie'], undefined);
+});
+
+for (const method of ['GET', 'OPTIONS', 'HEAD']) {
+  test(`${method} method is preserved to the upstream`, async () => {
+    await run({ path: '/client/echo', method });
+    assert.equal(mock.requests[0].method, method);
+  });
+}
+
+// --- 4. Status relay: verbatim status, success/failure split at 400. -----------
+const STATUSES = [
+  [301, 1, 0],
+  [304, 1, 0],
+  [404, 0, 1],
+  [500, 0, 1],
+];
+
+for (const [status, success, failure] of STATUSES) {
+  test(`upstream ${status} is relayed verbatim`, async () => {
+    const res = await run({ path: `/static/status/${status}` });
+    assert.equal(res.status, status);
+    assert.equal(res.gtmOnSuccessCalls, success);
+    assert.equal(res.gtmOnFailureCalls, failure);
+    if (status === 301) assert.equal(res.headers['location'], 'https://example.com/moved');
+  });
+}
+
+// --- 5. Hop-by-hop response headers are stripped over real HTTP. ---------------
+test('hop-by-hop response headers are stripped and normal headers relayed', async () => {
+  const res = await run({ path: '/client/hop-headers' });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers['x-custom'], 'keep-me');
+  for (const dropped of ['connection', 'keep-alive', 'proxy-authenticate', 'upgrade', 'content-length']) {
+    assert.equal(res.headers[dropped], undefined, `expected ${dropped} to be stripped`);
+  }
+});
+
+// --- 6. Upstream connection error maps to a deterministic 502. -----------------
+test('upstream connection error returns 502 Bad Gateway', async () => {
+  const res = await run({ path: '/api/v1/network-error' });
+  assert.equal(res.status, 502);
+  assert.equal(res.body.toString(), 'Bad Gateway');
+  assert.equal(res.gtmOnFailureCalls, 1);
+});
+
+// --- 7. Proxy base path stripping over the full request flow. ------------------
+for (const basePath of ['/axeptio', 'axeptio', '/axeptio/']) {
+  test(`base path "${basePath}" is stripped before routing`, async () => {
+    const res = await run({ path: '/axeptio/static/echo', data: { proxyBasePath: basePath } });
+    assert.equal(res.status, 200);
+    assert.equal(mock.requests[0].host, 'static.axept.io');
+  });
+}
+
+for (const basePath of ['/', '']) {
+  test(`root base path "${basePath}" leaves routing untouched`, async () => {
+    const res = await run({ path: '/static/echo', data: { proxyBasePath: basePath } });
+    assert.equal(res.status, 200);
+    assert.equal(mock.requests[0].host, 'static.axept.io');
+  });
+}
+
+test('base path never mis-strips the non-boundary prefix axeptiofoo', async () => {
+  const res = await run({ path: '/axeptiofoo/static/echo', data: { proxyBasePath: '/axeptio' } });
+  assert.equal(res.status, 404);
+  assert.equal(mock.requests.length, 0);
+});
+
+// --- 8. Unmatched path: 404, no upstream traffic. ------------------------------
+test('unmatched path returns 404 without contacting any upstream', async () => {
+  const res = await run({ path: '/nope' });
+  assert.equal(res.status, 404);
+  assert.equal(res.body.toString(), 'Not Found');
+  assert.equal(res.gtmOnFailureCalls, 1);
+  assert.equal(mock.requests.length, 0);
+});

--- a/lib/template.mjs
+++ b/lib/template.mjs
@@ -1,0 +1,48 @@
+// Shared template.tpl tooling for the headless unit runner (test/run-tpl-tests.mjs)
+// and the integration harness (integration/). Pure extraction — no runner-specific
+// behavior lives here.
+
+import { readFileSync } from 'node:fs';
+import yaml from 'js-yaml';
+
+// --- Parse the .tpl into its ___SECTION___ blocks. ----------------------------
+export function parseTemplate(src) {
+  const names = src.match(/___[A-Z_]+___/g) || [];
+  const chunks = src.split(/___[A-Z_]+___/);
+  const sections = {};
+  names.forEach((name, i) => {
+    sections[name] = chunks[i + 1].trim();
+  });
+  return sections;
+}
+
+export function loadTemplate(tplPath) {
+  const sections = parseTemplate(readFileSync(tplPath, 'utf8'));
+  const sandboxSource = sections.___SANDBOXED_JS_FOR_SERVER___;
+  if (!sandboxSource) {
+    throw new Error('Could not extract ___SANDBOXED_JS_FOR_SERVER___ from template.tpl');
+  }
+  const tests = yaml.load(sections.___TESTS___ || '') || {};
+  return { sections, sandboxSource, tests };
+}
+
+// --- Spies. -------------------------------------------------------------------
+export function spy(impl) {
+  const fn = (...args) => {
+    fn.calls.push(args);
+    return typeof impl === 'function' ? impl(...args) : undefined;
+  };
+  fn.calls = [];
+  return fn;
+}
+
+export function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+  const ka = Object.keys(a);
+  const kb = Object.keys(b);
+  if (ka.length !== kb.length) return false;
+  // Require b to own every key of a; with equal key counts this guarantees the
+  // key sets are identical, so {a: undefined} no longer matches {b: 1}.
+  return ka.every((k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Tooling to unit-test the Axeptio sGTM custom template (template.tpl). Not published; the template itself is distributed via the GTM Community Template Gallery.",
   "scripts": {
     "test": "node --test",
+    "integration": "node --test integration/proxy-integration.mjs",
     "e2e": "node --test e2e/proxy-e2e.mjs"
   },
   "devDependencies": {

--- a/test/run-tpl-tests.mjs
+++ b/test/run-tpl-tests.mjs
@@ -10,35 +10,17 @@
 // It runs the REAL sandboxed source extracted from template.tpl (never a copy), so
 // a regression in the template's routing makes a scenario fail here.
 
-import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import vm from 'node:vm';
 import { test } from 'node:test';
-import yaml from 'js-yaml';
+import { loadTemplate, spy, deepEqual } from '../lib/template.mjs';
 
 const TPL_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'template.tpl');
 
-// --- Parse the .tpl into its ___SECTION___ blocks. ----------------------------
-function parseTemplate(src) {
-  const names = src.match(/___[A-Z_]+___/g) || [];
-  const chunks = src.split(/___[A-Z_]+___/);
-  const sections = {};
-  names.forEach((name, i) => {
-    sections[name] = chunks[i + 1].trim();
-  });
-  return sections;
-}
-
-const sections = parseTemplate(readFileSync(TPL_PATH, 'utf8'));
-const sandboxSource = sections.___SANDBOXED_JS_FOR_SERVER___;
-const parsedTests = yaml.load(sections.___TESTS___ || '') || {};
+const { sandboxSource, tests: parsedTests } = loadTemplate(TPL_PATH);
 const scenarios = parsedTests.scenarios || [];
 const sharedSetup = parsedTests.setup || '';
-
-if (!sandboxSource) {
-  throw new Error('Could not extract ___SANDBOXED_JS_FOR_SERVER___ from template.tpl');
-}
 
 // --- Synchronous promise. -----------------------------------------------------
 // GTM resolves a mocked sendHttpRequest()'s promise synchronously inside runCode,
@@ -78,27 +60,6 @@ class SyncPromise {
     }
   }
   catch(onRejected) { return this.then(undefined, onRejected); }
-}
-
-// --- Spies. -------------------------------------------------------------------
-function spy(impl) {
-  const fn = (...args) => {
-    fn.calls.push(args);
-    return typeof impl === 'function' ? impl(...args) : undefined;
-  };
-  fn.calls = [];
-  return fn;
-}
-
-function deepEqual(a, b) {
-  if (a === b) return true;
-  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
-  const ka = Object.keys(a);
-  const kb = Object.keys(b);
-  if (ka.length !== kb.length) return false;
-  // Require b to own every key of a; with equal key counts this guarantees the
-  // key sets are identical, so {a: undefined} no longer matches {b: 1}.
-  return ka.every((k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
 }
 
 // --- Per-scenario GTM Test API. -----------------------------------------------


### PR DESCRIPTION
## Summary

Part A of [SUP-998](https://linear.app/axeptio/issue/SUP-998) — adds the missing integration layer between the mocked `___TESTS___` unit scenarios (PR gate) and the weekly live e2e run.

- **`integration/` hermetic suite (27 tests, zero egress)**: runs the real `___SANDBOXED_JS_FOR_SERVER___` over real HTTP against a local fixture server emulating the six Axeptio upstream origins. Asserts byte-identical binary relay (deterministic 4KB pattern covering 0x00–0xFF), request-header allowlist + hop-by-hop response stripping on the wire, verbatim status relay (301/304/404/500) with the gtmOnSuccess/Failure split, 502 mapping on connection errors, base-path stripping incl. the `/axeptiofoo` boundary, and 404-with-no-upstream-traffic.
- **Permission fidelity**: the `sendHttpRequest` shim enforces a mirror of the `send_http` allowlist *before* rewriting hosts to the mock, and a drift-guard test pins that mirror to `___SERVER_PERMISSIONS___` — the rewrite can never mask a permission regression.
- **Refactor**: shared `.tpl` parsing/spy helpers move from `test/run-tpl-tests.mjs` to `lib/template.mjs` (kept outside `node --test` auto-discovery). Unit suite unchanged: 16 passing.
- **CI**: `npm run integration` added to the existing `Test template` job (required-check name unchanged). CONTRIBUTING documents the new suite and its fidelity contract vs live e2e (which stays the only proof of end-to-end binary integrity on a real tagging server).

Part B (Tag Manager API staging sync) follows separately once the WIF/service-account infra exists.

## Verification

- `npm test` → 16/16 (unchanged after refactor)
- `npm run integration` → 27/27
- Mutation check: flipping one upstream origin in the routes table fails the suite; restore → green
- Bare `node --test` still discovers only `test/` (no accidental pickup of `integration/` or `e2e/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)