### PR TITLE
chore(metadata): keep gallery versions list newest-first

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,7 +15,6 @@ versions:
   - sha: 17a9426122c9c0106c891dc24366c578a0941198
     changeNotes: |-
       - **template:** source request path/query/body from request APIs
-      - **template:** source request path/query/body from request APIs
       - **template:** fix harness comment on unmocked request APIs
   - sha: 0c5811dde913854007afdab6e0ce25a8871aff53
     changeNotes: |-

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,12 +10,19 @@
 
 homepage: "https://www.example.com"
 documentation: "https://www.example.com/documentation"
+# The gallery requires reverse chronological order: most recent version first.
 versions:
-  - sha: f311fd0a2da4911824ff9dfd435805ec89d083a4
-    changeNotes: Initial Version
-  - sha: a299456826a01e4db72e593ed01c35fe7cd000cd
+  - sha: 17a9426122c9c0106c891dc24366c578a0941198
     changeNotes: |-
-      - **ci:** use .mjs commitlint config required by commitlint action
+      - **template:** source request path/query/body from request APIs
+      - **template:** source request path/query/body from request APIs
+      - **template:** fix harness comment on unmocked request APIs
+  - sha: 0c5811dde913854007afdab6e0ce25a8871aff53
+    changeNotes: |-
+      - replace Apache 2.0 with Axeptio license notice (from v1.2.0)
+  - sha: 6557523481fedee9b30a87e4096a7ec08e7f99bd
+    changeNotes: |-
+      - **test:** tighten deepEqual key-set check in template test runner
   - sha: 206848857b6924edce02f9e8d1ee2aea279c09aa
     changeNotes: |-
       - full proxyBaseUrl reverse proxy for all Axeptio origins
@@ -24,14 +31,8 @@ versions:
       - address Copilot round 3 on proxy template
       - address Copilot round 4 on proxy template
       - address Copilot round 5 on proxy template
-  - sha: 6557523481fedee9b30a87e4096a7ec08e7f99bd
+  - sha: a299456826a01e4db72e593ed01c35fe7cd000cd
     changeNotes: |-
-      - **test:** tighten deepEqual key-set check in template test runner
-  - sha: 0c5811dde913854007afdab6e0ce25a8871aff53
-    changeNotes: |-
-      - replace Apache 2.0 with Axeptio license notice (from v1.2.0)
-  - sha: 17a9426122c9c0106c891dc24366c578a0941198
-    changeNotes: |-
-      - **template:** source request path/query/body from request APIs
-      - **template:** source request path/query/body from request APIs
-      - **template:** fix harness comment on unmocked request APIs
+      - **ci:** use .mjs commitlint config required by commitlint action
+  - sha: f311fd0a2da4911824ff9dfd435805ec89d083a4
+    changeNotes: Initial Version

--- a/scripts/update-metadata-version.mjs
+++ b/scripts/update-metadata-version.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
-// Appends a new entry to the `versions:` list in metadata.yaml so the GTM
+// Prepends a new entry to the `versions:` list in metadata.yaml so the GTM
 // Community Template Gallery version history stays in sync with releases.
+// The gallery requires reverse chronological order (most recent version
+// first), so new entries go directly under the `versions:` key.
 //
 // Invoked by .github/workflows/release-please.yml after a release is published.
 // Inputs (environment):
@@ -64,7 +66,7 @@ function buildChangeNotes() {
   return lines.join('\n');
 }
 
-// --- Append the new version entry to metadata.yaml -------------------------
+// --- Prepend the new version entry to metadata.yaml ------------------------
 
 let metadata = readFileSync(METADATA_PATH, 'utf8');
 
@@ -73,7 +75,8 @@ if (metadata.includes(sha)) {
   process.exit(0);
 }
 
-if (!/\n?versions:\s*\n/.test(metadata) && !/\nversions:\s*$/.test(metadata)) {
+const versionsKey = metadata.match(/^versions:[ \t]*\r?\n/m);
+if (!versionsKey) {
   console.error('Could not find a `versions:` key in metadata.yaml.');
   process.exit(1);
 }
@@ -92,5 +95,7 @@ const notesBlock = changeNotes
 
 const entry = `  - sha: ${sha}\n    changeNotes: |-\n${notesBlock}\n`;
 
-writeFileSync(METADATA_PATH, metadata + entry, 'utf8');
-console.log(`Appended ${tag} (${sha}) to ${METADATA_PATH}.`);
+// Insert directly under `versions:` so the newest release is listed first.
+const insertAt = versionsKey.index + versionsKey[0].length;
+writeFileSync(METADATA_PATH, metadata.slice(0, insertAt) + entry + metadata.slice(insertAt), 'utf8');
+console.log(`Prepended ${tag} (${sha}) to ${METADATA_PATH}.`);

--- a/scripts/update-metadata-version.mjs
+++ b/scripts/update-metadata-version.mjs
@@ -75,13 +75,15 @@ if (metadata.includes(sha)) {
   process.exit(0);
 }
 
+// Normalize before matching so a file ending exactly at `versions:` (no
+// trailing newline) still matches and gets its entry inserted below the key.
+if (!metadata.endsWith('\n')) metadata += '\n';
+
 const versionsKey = metadata.match(/^versions:[ \t]*\r?\n/m);
 if (!versionsKey) {
   console.error('Could not find a `versions:` key in metadata.yaml.');
   process.exit(1);
 }
-
-if (!metadata.endsWith('\n')) metadata += '\n';
 
 const changeNotes = buildChangeNotes();
 


### PR DESCRIPTION
## Summary

Fixes the real defect behind the "gallery only picks the previous release / you need two releases" folklore ([SUP-998](https://linear.app/axeptio/issue/SUP-998) thread, beads `sgtm-rmg`):

- Google's Community Template Gallery [requires](https://developers.google.com/tag-platform/tag-manager/templates/gallery) the `metadata.yaml` `versions` list in **reverse chronological order (most recent first)** and resolves the served template from it. Our sync script **appended** each release, so the list was oldest-first — leaving the gallery on a stale version.
- **`metadata.yaml`**: the six existing entries reordered newest-first (v1.2.1 → initial). Shas untouched — they already point exactly at the tagged release commits (verified against `v1.2.0`/`v1.2.1`).
- **`scripts/update-metadata-version.mjs`**: now prepends new entries directly under the `versions:` key.

Typed `chore` deliberately: the gallery reads `metadata.yaml` from default-branch HEAD, so the correction takes effect on merge (next crawl, ~2–3 days) without cutting a content-identical release.

## Verification

- Fake-release dry run (`RELEASE_TAG=v9.9.9`): entry lands directly under `versions:`, ahead of v1.2.1; file stays valid YAML (7 entries, newest first)
- Idempotency: re-run with the same sha → "nothing to do", file untouched
- `npm test` 16/16, `npm run integration` 27/27

🤖 Generated with [Claude Code](https://claude.com/claude-code)