### PR TITLE
feat(ci): add Tag Manager API staging push script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,18 @@
       "version": "0.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
+        "google-auth-library": "^10.9.0",
         "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/argparse": {
@@ -18,6 +29,198 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -30,6 +233,117 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e": "node --test e2e/proxy-e2e.mjs"
   },
   "devDependencies": {
+    "google-auth-library": "^10.9.0",
     "js-yaml": "^4.1.0"
   },
   "license": "SEE LICENSE IN LICENSE"

--- a/scripts/push-template-to-staging.mjs
+++ b/scripts/push-template-to-staging.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// Publishes the local template.tpl into a staging GTM Server container via the
+// Tag Manager API v2, so the live e2e suite always validates the current
+// template instead of a manually-imported (possibly stale) copy.
+//
+// Flow (default mode):
+//   1. GET  versions:live                 -> record the current live version id
+//   2. POST workspaces                    -> ephemeral workspace ci-sync-<sha>
+//   3. GET  workspaces/W/templates        -> find the template by display name
+//   4. no-op check: local == remote       -> delete workspace, exit changed=false
+//   5. PUT  templates/T?fingerprint=<fp>  -> replace templateData
+//   6. POST workspaces/W:create_version   -> compile + snapshot (fails loud on
+//                                            compilerError / dirty syncStatus)
+//   7. POST versions/V:publish?fingerprint=<fp>  -> make it live
+//   8. best-effort delete the ephemeral workspace (create_version usually
+//      consumes it; tolerate an already-gone workspace)
+//
+// Auth: Application Default Credentials (google-auth-library). In CI these come
+// from google-github-actions/auth (Workload Identity Federation); locally, from
+// `gcloud auth application-default login`. The service account / user must be a
+// member of the GTM container with Edit + Publish (GTM's own ACL, not GCP IAM).
+//
+// Modes:
+//   --dry-run            steps 1-4 only: prove auth, locate the template, report
+//                        whether a publish WOULD happen. Creates and deletes an
+//                        ephemeral workspace but never versions or publishes.
+//   --rollback <id>      re-publish an existing container version id (GTM's
+//                        canonical rollback), then exit. No workspace/version.
+//
+// Env:
+//   GTM_ACCOUNT_ID     (required) numeric account id
+//   GTM_CONTAINER_ID   (required) numeric container id of the staging container
+//   GTM_TEMPLATE_NAME  (optional) template display name; default "Axeptio CMP"
+//   GTM_VERSION_NAME   (optional) label for the created version; default "ci <sha>"
+//   GTM_API_MIN_INTERVAL_MS (optional) min spacing between API calls; default 4000
+//                        (GTM's default quota is ~0.25 QPS / 10k per day)
+//   GITHUB_SHA / GITHUB_OUTPUT  consumed when present (CI); optional locally.
+//
+// Node built-ins + google-auth-library only. No googleapis SDK.
+
+import { readFileSync, appendFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { GoogleAuth } from 'google-auth-library';
+
+const TPL_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'template.tpl');
+const API_BASE = 'https://tagmanager.googleapis.com/tagmanager/v2';
+
+// Union of every scope the flow touches. Note tagmanager.delete.containers:
+// deleting the ephemeral workspace needs it, beyond edit/version/publish.
+const SCOPES = [
+  'https://www.googleapis.com/auth/tagmanager.edit.containers',
+  'https://www.googleapis.com/auth/tagmanager.edit.containerversions',
+  'https://www.googleapis.com/auth/tagmanager.publish',
+  'https://www.googleapis.com/auth/tagmanager.delete.containers',
+];
+
+// --- CLI / env ----------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const rollbackIdx = args.indexOf('--rollback');
+const rollbackVersionId = rollbackIdx !== -1 ? args[rollbackIdx + 1] : null;
+if (rollbackIdx !== -1 && !rollbackVersionId) {
+  fail('--rollback requires a container version id, e.g. --rollback 42');
+}
+
+const accountId = requireEnv('GTM_ACCOUNT_ID');
+const containerId = requireEnv('GTM_CONTAINER_ID');
+const templateName = process.env.GTM_TEMPLATE_NAME?.trim() || 'Axeptio CMP';
+const sha = (process.env.GITHUB_SHA || 'local').slice(0, 7);
+const versionName = process.env.GTM_VERSION_NAME?.trim() || `ci ${sha}`;
+const minIntervalMs = Number(process.env.GTM_API_MIN_INTERVAL_MS || 4000);
+
+const containerPath = `accounts/${accountId}/containers/${containerId}`;
+
+function requireEnv(name) {
+  const v = process.env[name]?.trim();
+  if (!v) fail(`${name} must be set.`);
+  return v;
+}
+
+function fail(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+// GitHub Actions step output; a plain log elsewhere.
+function setOutput(key, value) {
+  console.log(`  ${key}=${value}`);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+  }
+}
+
+// --- Rate-limited API client --------------------------------------------------
+
+const auth = new GoogleAuth({ scopes: SCOPES });
+let client;
+let lastCallAt = 0;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+class ApiError extends Error {
+  constructor(status, method, path, body) {
+    super(`${method} ${path} -> ${status}: ${body}`);
+    this.status = status;
+  }
+}
+
+// One request, honoring a minimum inter-call interval and retrying on 429/5xx
+// with exponential backoff. `path` is relative to API_BASE; `query` is an
+// object; `body` is JSON-serialized when present. Throws ApiError on a
+// non-retryable non-2xx so callers can react to specific statuses (e.g. a 404
+// from versions:live meaning "no live version yet"); the top-level handler
+// turns any uncaught ApiError into a clean failure.
+async function api(method, path, { query, body } = {}) {
+  if (!client) client = await auth.getClient();
+
+  const url = new URL(`${API_BASE}/${path}`);
+  for (const [k, v] of Object.entries(query || {})) {
+    if (v !== undefined && v !== null) url.searchParams.set(k, v);
+  }
+
+  for (let attempt = 0; ; attempt++) {
+    const wait = lastCallAt + minIntervalMs - Date.now();
+    if (wait > 0) await sleep(wait);
+    lastCallAt = Date.now();
+
+    const { token } = await client.getAccessToken();
+    const res = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const text = await res.text();
+
+    if (res.status === 429 || res.status >= 500) {
+      if (attempt >= 5) {
+        throw new ApiError(res.status, method, path, `after ${attempt + 1} attempts: ${text}`);
+      }
+      const backoff = Math.min(60000, 2 ** attempt * 1000);
+      console.warn(`  ${res.status} on ${method} ${path}; retrying in ${backoff}ms`);
+      await sleep(backoff);
+      continue;
+    }
+
+    if (!res.ok) throw new ApiError(res.status, method, path, text);
+    return text ? JSON.parse(text) : {};
+  }
+}
+
+// --- Flow steps ---------------------------------------------------------------
+
+// GTM stores templateData with normalized trailing whitespace; compare loosely
+// so an incidental trailing newline never forces a needless republish.
+const norm = (s) => (s || '').replace(/\s+$/, '');
+
+async function getLiveVersionId() {
+  // A brand-new container has no live version yet; GTM answers 404. Any other
+  // error (auth, permission, network) must surface, not be swallowed.
+  try {
+    const live = await api('GET', `${containerPath}/versions:live`);
+    return live?.containerVersionId || null;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
+}
+
+async function findTemplate(workspacePath) {
+  const res = await api('GET', `${workspacePath}/templates`);
+  const match = (res.template || []).find((t) => t.name === templateName);
+  if (!match) {
+    // Throw (not fail): main()'s catch must run to clean up the workspace.
+    throw new Error(`No template named "${templateName}" in the staging container. ` +
+      `Import it once in the GTM UI, then re-run.`);
+  }
+  return match;
+}
+
+async function rollback() {
+  console.log(`Rollback: re-publishing container version ${rollbackVersionId}`);
+  const version = await api('GET', `${containerPath}/versions/${rollbackVersionId}`);
+  await api('POST', `${containerPath}/versions/${rollbackVersionId}:publish`, {
+    query: { fingerprint: version.fingerprint },
+  });
+  setOutput('published_version', rollbackVersionId);
+  console.log(`Rollback complete: version ${rollbackVersionId} is now live.`);
+}
+
+async function main() {
+  const localData = readFileSync(TPL_PATH, 'utf8');
+
+  if (rollbackVersionId) {
+    await rollback();
+    return;
+  }
+
+  const previousLiveVersion = await getLiveVersionId();
+  setOutput('previous_live_version', previousLiveVersion ?? '');
+
+  // Ephemeral workspace based on the latest container version, so we never
+  // touch pending edits in anyone else's workspace.
+  const workspace = await api('POST', `${containerPath}/workspaces`, {
+    body: { name: `ci-sync-${sha}`, description: `Automated template sync for ${versionName}` },
+  });
+  const workspacePath = workspace.path;
+  console.log(`Created ephemeral workspace ${workspace.workspaceId}`);
+
+  // Always try to clean the workspace up, even on an error path.
+  let workspaceLives = true;
+  const deleteWorkspace = async () => {
+    if (!workspaceLives) return;
+    workspaceLives = false;
+    await api('DELETE', workspacePath).catch((e) => console.warn(`  workspace cleanup: ${e.message}`));
+  };
+
+  try {
+    const template = await findTemplate(workspacePath);
+
+    if (norm(template.templateData) === norm(localData)) {
+      console.log('Staging template already matches local template.tpl; nothing to publish.');
+      await deleteWorkspace();
+      setOutput('changed', 'false');
+      return;
+    }
+
+    if (dryRun) {
+      console.log('[dry-run] Template differs; a real run would update, version and publish.');
+      await deleteWorkspace();
+      setOutput('changed', 'false');
+      return;
+    }
+
+    // Replace only templateData; echo back the rest of the resource (incl.
+    // galleryReference) so nothing else is disturbed. fingerprint guards
+    // against a concurrent edit landing between our GET and PUT. The template
+    // resource carries its own API-relative `path`.
+    await api('PUT', template.path, {
+      query: { fingerprint: template.fingerprint },
+      body: { ...template, templateData: localData },
+    });
+    console.log('Updated templateData in the ephemeral workspace.');
+
+    const created = await api('POST', `${workspacePath}:create_version`, {
+      body: { name: versionName, notes: `Automated sync of template.tpl at ${sha}` },
+    });
+    // Throw (not fail) on these: main()'s catch cleans up the workspace, which
+    // create_version leaves intact when it does not produce a version.
+    if (created.compilerError) {
+      throw new Error('create_version reported a compilerError; not publishing.');
+    }
+    if (created.syncStatus && (created.syncStatus.mergeConflict || created.syncStatus.syncError)) {
+      throw new Error(`create_version reported a dirty syncStatus: ${JSON.stringify(created.syncStatus)}`);
+    }
+    const version = created.containerVersion;
+    if (!version?.containerVersionId) {
+      throw new Error('create_version returned no container version; nothing to publish.');
+    }
+    // create_version consumes the workspace on success.
+    workspaceLives = false;
+    console.log(`Created container version ${version.containerVersionId}`);
+
+    await api('POST', `${containerPath}/versions/${version.containerVersionId}:publish`, {
+      query: { fingerprint: version.fingerprint },
+    });
+    console.log(`Published version ${version.containerVersionId} to the staging container.`);
+
+    setOutput('changed', 'true');
+    setOutput('published_version', version.containerVersionId);
+  } catch (err) {
+    await deleteWorkspace();
+    throw err;
+  }
+}
+
+main().catch((err) => fail(err.stack || err.message));

--- a/scripts/push-template-to-staging.mjs
+++ b/scripts/push-template-to-staging.mjs
@@ -71,6 +71,9 @@ const templateName = process.env.GTM_TEMPLATE_NAME?.trim() || 'Axeptio CMP';
 const sha = (process.env.GITHUB_SHA || 'local').slice(0, 7);
 const versionName = process.env.GTM_VERSION_NAME?.trim() || `ci ${sha}`;
 const minIntervalMs = Number(process.env.GTM_API_MIN_INTERVAL_MS || 4000);
+if (!Number.isFinite(minIntervalMs) || minIntervalMs < 0) {
+  fail('GTM_API_MIN_INTERVAL_MS must be a non-negative number.');
+}
 
 const containerPath = `accounts/${accountId}/containers/${containerId}`;
 
@@ -128,6 +131,10 @@ async function api(method, path, { query, body } = {}) {
     lastCallAt = Date.now();
 
     const { token } = await client.getAccessToken();
+    // Fail fast rather than sending "Authorization: Bearer undefined", which
+    // turns a credential problem into an opaque 401. Throw (not fail) so the
+    // caller's cleanup runs.
+    if (!token) throw new Error('ADC returned no access token; check credentials and scopes.');
     const res = await fetch(url, {
       method,
       headers: {
@@ -185,10 +192,15 @@ async function findTemplate(workspacePath) {
 
 async function rollback() {
   console.log(`Rollback: re-publishing container version ${rollbackVersionId}`);
+  // Emit the same output set as the default flow so downstream steps behave
+  // consistently across modes.
+  const previousLiveVersion = await getLiveVersionId();
+  setOutput('previous_live_version', previousLiveVersion ?? '');
   const version = await api('GET', `${containerPath}/versions/${rollbackVersionId}`);
   await api('POST', `${containerPath}/versions/${rollbackVersionId}:publish`, {
     query: { fingerprint: version.fingerprint },
   });
+  setOutput('changed', 'true');
   setOutput('published_version', rollbackVersionId);
   console.log(`Rollback complete: version ${rollbackVersionId} is now live.`);
 }
@@ -233,7 +245,9 @@ async function main() {
     if (dryRun) {
       console.log('[dry-run] Template differs; a real run would update, version and publish.');
       await deleteWorkspace();
-      setOutput('changed', 'false');
+      // changed=true reflects "a publish would happen" — consistent with the
+      // log and with the no-op branch above, which reports changed=false.
+      setOutput('changed', 'true');
       return;
     }
 

--- a/scripts/push-template-to-staging.mjs
+++ b/scripts/push-template-to-staging.mjs
@@ -61,8 +61,10 @@ const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
 const rollbackIdx = args.indexOf('--rollback');
 const rollbackVersionId = rollbackIdx !== -1 ? args[rollbackIdx + 1] : null;
-if (rollbackIdx !== -1 && !rollbackVersionId) {
-  fail('--rollback requires a container version id, e.g. --rollback 42');
+if (rollbackIdx !== -1 && !/^\d+$/.test(rollbackVersionId || '')) {
+  // Reject a missing id or the next flag (e.g. `--rollback --dry-run`) up front,
+  // rather than letting it become a confusing API 404.
+  fail('--rollback requires a numeric container version id, e.g. --rollback 42');
 }
 
 const accountId = requireEnv('GTM_ACCOUNT_ID');
@@ -224,12 +226,20 @@ async function main() {
   const workspacePath = workspace.path;
   console.log(`Created ephemeral workspace ${workspace.workspaceId}`);
 
-  // Always try to clean the workspace up, even on an error path.
+  // Always try to clean the workspace up, even on an error path. A successful
+  // create_version consumes the workspace, so a 404 here is expected and benign
+  // — tolerate it silently and only warn on a genuine cleanup failure.
   let workspaceLives = true;
   const deleteWorkspace = async () => {
     if (!workspaceLives) return;
     workspaceLives = false;
-    await api('DELETE', workspacePath).catch((e) => console.warn(`  workspace cleanup: ${e.message}`));
+    try {
+      await api('DELETE', workspacePath);
+    } catch (err) {
+      if (!(err instanceof ApiError && err.status === 404)) {
+        console.warn(`  workspace cleanup: ${err.message}`);
+      }
+    }
   };
 
   try {
@@ -276,14 +286,17 @@ async function main() {
     if (!version?.containerVersionId) {
       throw new Error('create_version returned no container version; nothing to publish.');
     }
-    // create_version consumes the workspace on success.
-    workspaceLives = false;
     console.log(`Created container version ${version.containerVersionId}`);
 
     await api('POST', `${containerPath}/versions/${version.containerVersionId}:publish`, {
       query: { fingerprint: version.fingerprint },
     });
     console.log(`Published version ${version.containerVersionId} to the staging container.`);
+
+    // create_version usually consumes the workspace, but don't rely on it:
+    // attempt the delete regardless (a 404 is tolerated) so a workspace can
+    // never leak if that behavior ever changes.
+    await deleteWorkspace();
 
     setOutput('changed', 'true');
     setOutput('published_version', version.containerVersionId);


### PR DESCRIPTION
## Summary

Part B of [SUP-998](https://linear.app/axeptio/issue/SUP-998), step 1 of 3 (beads `sgtm-tgi.4`). Adds `scripts/push-template-to-staging.mjs` — the script that publishes the local `template.tpl` into a staging GTM Server container via the **Tag Manager API v2**, closing the gap where the Addingwell test container's template is imported by hand and the weekly e2e can validate a stale copy.

**Flow** (default mode):
1. `GET versions:live` → record current live version (for rollback)
2. `POST workspaces` → ephemeral `ci-sync-<sha>` (never touches anyone's pending edits)
3. `GET workspaces/W/templates` → locate the template by display name
4. **no-op check**: `templateData` already matches local → delete workspace, `changed=false`, exit
5. `PUT templates/T?fingerprint=<fp>` → replace only `templateData` (echoes back `galleryReference` etc.)
6. `POST workspaces/W:create_version` → fail loud on `compilerError` / dirty `syncStatus`
7. `POST versions/V:publish?fingerprint=<fp>` → make it live

The ephemeral workspace is cleaned up on **every** path including errors, so a failed run never leaks a workspace.

**Auth**: ADC via `google-auth-library` (devDep) — Workload Identity Federation in CI, `gcloud auth application-default login` locally. Native `fetch`, no `googleapis` SDK.

**Modes**: `--dry-run` (locate + report, creates/deletes a workspace but never versions or publishes) and `--rollback <id>` (re-publish an existing version — GTM's canonical rollback). Emits `changed` / `published_version` / `previous_live_version` as GitHub step outputs.

### API paths verified against the discovery document

Confirmed every path/method/scope against `googleapis/google-api-go-client` `tagmanager/v2/tagmanager-api.json`, which corrected two things from the initial design: deleting the ephemeral workspace needs the extra **`tagmanager.delete.containers`** scope, and `templates.update` is **PUT** (a docs HTML page wrongly said PATCH).

## What this PR is *not*

The workflow that invokes this script (`staging-sync.yml`, `sgtm-tgi.6`) and the one-time GCP WIF + service-account + GTM-container-user setup (`sgtm-tgi.5`) are follow-ups — the latter is blocked on the Addingwell container provisioning (`sgtm-giw.6`). End-to-end `--dry-run` verification against the real container will happen when that infra exists; user-facing docs land with the workflow PR.

## Verification (offline)

- `node --check` clean; env guards fire (missing `GTM_ACCOUNT_ID`, `--rollback` without id)
- URL colon-suffix handling (`:live`/`:create_version`/`:publish`) + fingerprint query verified
- Silent-failure review caught + fixed: `api()` now throws a typed `ApiError` so a legitimate "no live version yet" 404 is handled instead of killing the script, and in-`try` validation failures throw (not `process.exit`) so workspace cleanup always runs
- `npm test` 16/16, `npm run integration` 27/27 unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)